### PR TITLE
Changed EOL from `CR LF` (Windows) to `LF` (Linux)

### DIFF
--- a/install/install_linux.sh
+++ b/install/install_linux.sh
@@ -1,6 +1,6 @@
 echo ""
 set -e
-
+ 
 # GitHub Org and repo hosting AI Hub
 GitHubOrg="azure"
 GitHubRepo="aihub"


### PR DESCRIPTION
Changed EOL from `CR LF` (Windows) to `LF` (Linux), to prevent issues with some Linux distros and platforms with invalid or unexpected EOLs.

This fixes issue #41 

**NOTE**: A blank space is added to the `install_linux.sh` file to force the detection of changes by GitHub.