### PR TITLE
Solved Issue 44: OpenAI Plugins (Azure Functions) should not be deployed by default

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -237,6 +237,7 @@ module "ca_aihub" {
 }
 
 module "plugin" {
+  count                    = var.enable_openai_plugin_call_transcript ? 1 : 0
   source                   = "./modules/ca-plugin"
   location                 = azurerm_resource_group.rg.location
   resource_group_name      = azurerm_resource_group.rg.name
@@ -252,6 +253,7 @@ module "plugin" {
 }
 
 module "plugin-fsi" {
+  count                    = var.enable_openai_plugin_compare_financial_products ? 1 : 0
   source                   = "./modules/ca-plugin-fsi"
   location                 = azurerm_resource_group.rg.location
   resource_group_name      = azurerm_resource_group.rg.name

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -137,3 +137,11 @@ variable "deploy_bing" {
 variable "pbi_report_link" {
   default = ""
 }
+
+variable "enable_openai_plugin_call_transcript" {
+  default = false
+}
+
+variable "enable_openai_plugin_compare_financial_products" {
+  default = false
+}


### PR DESCRIPTION
Solves issue #44 by:

- Adding new variables to enable the OpenAI plugin call transcript and compare financial products deployments. These variables are set to `false` by default.
- Update `main.tf` to conditionally enable OpenAI plugin deployments for call transcript and compare financial products