### PR TITLE
Fix updating the Azure API Management

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -62,6 +62,7 @@ module "apim" {
   count                    = var.enable_apim ? 1 : 0
   source                   = "./modules/apim"
   location                 = azurerm_resource_group.rg.location
+  resource_group_id        = azurerm_resource_group.rg.id
   resource_group_name      = azurerm_resource_group.rg.name
   apim_name                = local.apim_name
   apim_subnet_id           = module.vnet.apim_subnet_id

--- a/infra/modules/apim/main.tf
+++ b/infra/modules/apim/main.tf
@@ -168,7 +168,6 @@ resource "azurerm_api_management_api_policy" "policy" {
         </on-error>
     </policies>
     XML
-  depends_on  = [azurerm_api_management_named_value.tenant_id]
 }
 
 # https://github.com/aavetis/azure-openai-logger/blob/main/README.md

--- a/infra/modules/apim/main.tf
+++ b/infra/modules/apim/main.tf
@@ -3,14 +3,10 @@ locals {
   backend_url = "${var.openai_service_endpoint}openai"
 }
 
-data "azurerm_resource_group" "rg" {
-  name = var.resource_group_name
-}
-
 resource "azapi_resource" "apim" {
   type      = "Microsoft.ApiManagement/service@2023-05-01-preview"
   name      = var.apim_name
-  parent_id = data.azurerm_resource_group.rg.id
+  parent_id = var.resource_group_id
   location  = var.location
   identity {
     type = "SystemAssigned"
@@ -172,7 +168,7 @@ resource "azurerm_api_management_api_policy" "policy" {
         </on-error>
     </policies>
     XML
-  depends_on  = [azurerm_api_management_backend.openai, azapi_resource.apim_backend_pool]
+  depends_on  = [azurerm_api_management_named_value.tenant_id]
 }
 
 # https://github.com/aavetis/azure-openai-logger/blob/main/README.md

--- a/infra/modules/apim/variables.tf
+++ b/infra/modules/apim/variables.tf
@@ -1,4 +1,5 @@
 variable "resource_group_name" {}
+variable "resource_group_id" {}
 variable "location" {}
 variable "apim_name" {}
 variable "publisher_name" {}


### PR DESCRIPTION
Previously on any update, Terraform was indicating a `forced replacement` due to a calculation of the resource group ID. Passing it as a variable from the main module helps Terraform no to force a replacement, and updating APIs and policies without issue.

Also, updated the dependency on the policy item to the tenant ID named value.